### PR TITLE
Handling broken packages gracefully. fixes #3

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -22,10 +22,12 @@ router.get('/', function(req, res) {
           if (registry.author)
             module.author = registry.author.name;
 
-          if (module.installedVersion === registry['dist-tags'].latest) {
+          if (registry['dist-tags'] && module.installedVersion === registry['dist-tags'].latest) {
             upToDate.push(module);
-          } else {
+          } else if (registry['dist-tags']) {
             updates.push(module);
+          } else {
+            console.warn('Skipped package ' + module.name + ' because it does not list a version!');
           }
 
           indexedModules += 1;


### PR DESCRIPTION
When a module does not expose dist-tags (for whatever reason) we'll handly it gracefully and print a warning (but skip the module)
