### PR TITLE
added "prestart" step to install dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "git://github.com/travishorn/npm-package-store.git"
   },
   "scripts": {
+    "prestart" : "npm install",
     "start": "node app"
   },
   "dependencies": {


### PR DESCRIPTION
should make https://github.com/travishorn/npm-package-store/pull/2 obsolete ;-)
